### PR TITLE
Attempt to filter out gateway devices

### DIFF
--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -152,7 +152,7 @@ class DaikinApi:
         res = {}
         for dev_data in json_data or []:
             device = Appliance(dev_data, self)
-            if 'GATEWAY' not in device.getValue('gateway', 'modelInfo'):
+            if 'GATEWAY' not in device.get_value('gateway', 'modelInfo'):
                 res[dev_data["id"]] = device
         return res
 

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -152,8 +152,11 @@ class DaikinApi:
         res = {}
         for dev_data in json_data or []:
             device = Appliance(dev_data, self)
-            if 'GATEWAY' not in device.get_value('gateway', 'modelInfo'):
-                res[dev_data["id"]] = device
+            device_model = device.get_value('gateway', 'modelInfo')
+            if device_model is None:
+                _LOGGER.info("Device '%s' is filtered out", device_model)
+            else:
+                 res[dev_data["id"]] = device
         return res
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -152,11 +152,11 @@ class DaikinApi:
         res = {}
         for dev_data in json_data or []:
             device = Appliance(dev_data, self)
-            device_model = device.get_value('gateway', 'modelInfo')
+            device_model = device.get_value("gateway", "modelInfo")
             if device_model is None:
                 _LOGGER.info("Device '%s' is filtered out", device_model)
             else:
-                 res[dev_data["id"]] = device
+                res[dev_data["id"]] = device
         return res
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -167,4 +167,6 @@ class DaikinApi:
         json_data = await self.getCloudDeviceDetails()
         for dev_data in json_data or []:
             if dev_data["id"] in self.hass.data[DOMAIN][DAIKIN_DEVICES]:
-                self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(dev_data)
+                self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(
+                    dev_data
+                )

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -150,8 +150,10 @@ class DaikinApi:
         """Get array of DaikinResidentialDevice objects and get their data."""
         devices = await self.getCloudDeviceDetails()
         res = {}
-        for dev in devices or []:
-            res[dev["id"]] = Appliance(dev, self)
+        for dev_json in devices or []:
+            device = Appliance(dev_json, self)
+            if 'GATEWAY' not in device.getValue('gateway', 'modelInfo'):
+                res[dev_json["id"]] = device
         return res
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -148,12 +148,12 @@ class DaikinApi:
 
     async def getCloudDevices(self):
         """Get array of DaikinResidentialDevice objects and get their data."""
-        devices = await self.getCloudDeviceDetails()
+        json_data = await self.getCloudDeviceDetails()
         res = {}
-        for dev_json in devices or []:
-            device = Appliance(dev_json, self)
+        for dev_data in json_data or []:
+            device = Appliance(dev_data, self)
             if 'GATEWAY' not in device.getValue('gateway', 'modelInfo'):
-                res[dev_json["id"]] = device
+                res[dev_data["id"]] = device
         return res
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
@@ -163,4 +163,5 @@ class DaikinApi:
 
         json_data = await self.getCloudDeviceDetails()
         for dev_data in json_data or []:
-            self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(dev_data)
+            if dev_data["id"] in self.hass.data[DOMAIN][DAIKIN_DEVICES]:
+                self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(dev_data)

--- a/custom_components/daikin_residential/manifest.json
+++ b/custom_components/daikin_residential/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "daikin_residential",
   "name": "Daikin Residential Controller",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "documentation": "https://github.com/rospogrigio/daikin_residential/",
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
Daikin supports some "gateway" devices (modelInfo contains "GATEWAY") that provide a different json from the BRP049C4x devices, and it is currently not handled. This PR filters them out, ignoring them.
