### PR TITLE
Login and retrieve tokenset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ Alternatively, you can install daikin_residential through HACS by adding this re
 
 # Usage:
 
-**NOTE: You must have your Daikin Cloud token set stored as a tokenset.json file in your /config folder (the same where configuration.yaml is). For instructions on how to retrieve this file, follow the guide at https://github.com/Apollon77/daikin-controller-cloud/blob/main/PROXY.md .**
+**NOTE: since v.2.0.x, the tokenset.json file is no longer needed because the integration can connect and retrieve the tokens autonomously. When installing v.2.0.x from a previous one, the integration must be deleted and re-added.**
 
 The integration can be configured in two ways:
 
 # 1. YAML config files
 
-Just add the following line to your configuration.yaml file, and the Daikin devices connected to your cloud account will be created.
+Just add the following lines to your configuration.yaml file specifying the email and password used in the Daikin Residential App, and the Daikin devices connected to your cloud account will be created.
 
 ```
 daikin_residential:
+  email: [your_email]
+  password: [your_pwd]
+
 ```
 
 
@@ -26,7 +29,7 @@ daikin_residential:
 
 Start by going to Configuration - Integration and pressing the "+ ADD INTEGRATION" button to create a new Integration, then select Daikin Residential Controller in the drop-down menu.
 
-Follow the instruction, you have actually nothing to configure, just make sure your tokenset.json fine is in the HA config folder. After pressing the "Submit" button, the integration will be added, and the Daikin devices connected to your cloud account will be created.
+Follow the instructions, you just have to type the email and password used in the Daikin Residential App. After pressing the "Submit" button, the integration will be added, and the Daikin devices connected to your cloud account will be created.
 
 
 # To-do list:
@@ -36,4 +39,4 @@ Follow the instruction, you have actually nothing to configure, just make sure y
 
 # Thanks to:
 
-This code is based on @Apollon77 's great work, in finding a way to retrieve the token set, and to send the HTTP commands over the cloud. This integration would not exist without his precious job.
+This code is based on @Apollon77 's great work, in finding a way to retrieve the token set, and to send the HTTP commands over the cloud. This integration would not exist without his precious job, my job was just to find a way to port his code from nodeJS to python, and then create the integration.

--- a/custom_components/daikin_residential/__init__.py
+++ b/custom_components/daikin_residential/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES, CONF_TOKENSET
+from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
 
 from .daikin_api import DaikinApi
 
@@ -31,10 +31,16 @@ MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=15)
 COMPONENT_TYPES = ["climate", "sensor", "switch"]
 
 
-CONFIG_SCHEMA = vol.Schema(vol.All({DOMAIN: vol.Schema({
-    vol.Required(CONF_EMAIL): str,
-    vol.Required(CONF_PASSWORD): str,
-})}), extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(
+    vol.All(
+        {
+            DOMAIN: vol.Schema(
+                {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+            )
+        }
+    ),
+    extra=vol.ALLOW_EXTRA,
+)
 
 
 async def async_setup(hass, config):

--- a/custom_components/daikin_residential/__init__.py
+++ b/custom_components/daikin_residential/__init__.py
@@ -5,10 +5,10 @@ import logging
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
+from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES, CONF_TOKENSET
 
 from .daikin_api import DaikinApi
 
@@ -31,7 +31,10 @@ MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=15)
 COMPONENT_TYPES = ["climate", "sensor", "switch"]
 
 
-CONFIG_SCHEMA = vol.Schema(vol.All({DOMAIN: vol.Schema({})}), extra=vol.ALLOW_EXTRA)
+CONFIG_SCHEMA = vol.Schema(vol.All({DOMAIN: vol.Schema({
+    vol.Required(CONF_EMAIL): str,
+    vol.Required(CONF_PASSWORD): str,
+})}), extra=vol.ALLOW_EXTRA)
 
 
 async def async_setup(hass, config):
@@ -52,7 +55,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Establish connection with Daikin."""
 
-    daikin_api = DaikinApi(hass)
+    daikin_api = DaikinApi(hass, entry)
     await daikin_api.getCloudDeviceDetails()
 
     devices = await daikin_api.getCloudDevices()

--- a/custom_components/daikin_residential/__init__.py
+++ b/custom_components/daikin_residential/__init__.py
@@ -5,7 +5,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, SERVICE_RELOAD
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
@@ -44,7 +44,22 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass, config):
-    """Establish connection with Daikin."""
+    """Setup the Daikin Residential component."""
+
+    async def _handle_reload(service):
+        """Handle reload service call."""
+        _LOGGER.debug("Reloading integration: retrieving new TokenSet.")
+        try:
+            daikin_api = hass.data[DOMAIN][DAIKIN_API]
+            data = daikin_api._config_entry.data.copy()
+            await daikin_api.retrieveAccessToken(data[CONF_EMAIL], data[CONF_PASSWORD])
+        except Exception as e:
+            _LOGGER.error("Failed to reload integration: %s", e)
+
+    hass.helpers.service.async_register_admin_service(
+        DOMAIN, SERVICE_RELOAD, _handle_reload
+    )
+
     if DOMAIN not in config:
         return True
 
@@ -55,6 +70,7 @@ async def async_setup(hass, config):
                 DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
             )
         )
+
     return True
 
 

--- a/custom_components/daikin_residential/__init__.py
+++ b/custom_components/daikin_residential/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, SERVICE_RELOAD
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES
+from .const import DOMAIN, DAIKIN_API, DAIKIN_DEVICES, CONF_TOKENSET
 
 from .daikin_api import DaikinApi
 
@@ -53,6 +53,10 @@ async def async_setup(hass, config):
             daikin_api = hass.data[DOMAIN][DAIKIN_API]
             data = daikin_api._config_entry.data.copy()
             await daikin_api.retrieveAccessToken(data[CONF_EMAIL], data[CONF_PASSWORD])
+            data[CONF_TOKENSET] = daikin_api.tokenSet
+            hass.config_entries.async_update_entry(
+                entry=daikin_api._config_entry, data=data
+            )
         except Exception as e:
             _LOGGER.error("Failed to reload integration: %s", e)
 

--- a/custom_components/daikin_residential/__init__.py
+++ b/custom_components/daikin_residential/__init__.py
@@ -48,7 +48,7 @@ async def async_setup(hass, config):
 
     async def _handle_reload(service):
         """Handle reload service call."""
-        _LOGGER.debug("Reloading integration: retrieving new TokenSet.")
+        _LOGGER.info("Reloading integration: retrieving new TokenSet.")
         try:
             daikin_api = hass.data[DOMAIN][DAIKIN_API]
             data = daikin_api._config_entry.data.copy()

--- a/custom_components/daikin_residential/config_flow.py
+++ b/custom_components/daikin_residential/config_flow.py
@@ -4,19 +4,19 @@ import logging
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
 from .daikin_api import DaikinApi
-from .const import DOMAIN
+from .const import DOMAIN, CONF_TOKENSET
 
 _LOGGER = logging.getLogger(__name__)
-
 
 @config_entries.HANDLERS.register(DOMAIN)
 class FlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
         """Initialize the Daikin config flow."""
@@ -25,9 +25,14 @@ class FlowHandler(config_entries.ConfigFlow):
     @property
     def schema(self):
         """Return current schema."""
-        return vol.Schema({})
+        return vol.Schema(
+            {
+                vol.Required(CONF_EMAIL): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
 
-    async def _create_entry(self):
+    async def _create_entry(self, email, password, tokenSet):
         """Register new entry."""
         # if not self.unique_id:
         #    await self.async_set_unique_id(password)
@@ -37,27 +42,49 @@ class FlowHandler(config_entries.ConfigFlow):
 
         await self.async_set_unique_id("DaikinResidentialController")
 
-        return self.async_create_entry(title="Daikin", data={})
+        return self.async_create_entry(
+            title='Daikin',
+            data={
+                CONF_EMAIL: email,
+                CONF_PASSWORD: password,
+                CONF_TOKENSET: tokenSet
+            },
+        )
 
-    async def _attempt_connection(self):
+    async def _attempt_connection(self, email, password):
         """Create device."""
         try:
-            daikin_api = DaikinApi(self.hass)
+            daikin_api = DaikinApi(self.hass, None)
         except Exception:
+            print("CAZZO1")
             return self.async_abort(reason="missing_config")
+        try:
+            await daikin_api.retrieveAccessToken(email, password)
+        except Exception:
+            print("CAZZO2")
+            return self.async_abort(reason="token_retrieval_failed")
         try:
             await daikin_api.getApiInfo()
         except Exception:
+            print("CAZZO3")
             return self.async_abort(reason="cannot_connect")
 
-        return await self._create_entry()
+        return await self._create_entry(email, password, daikin_api.tokenSet)
 
     async def async_step_user(self, user_input=None):
         """User initiated config flow."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=self.schema)
-        return await self._attempt_connection()
+        return await self._attempt_connection(
+            user_input.get(CONF_EMAIL),
+            user_input.get(CONF_PASSWORD),
+        )
 
     async def async_step_import(self, user_input):
-        """Import a config entry."""
-        return await self._create_entry()
+        """Import a config entry from YAML."""
+        print("YAML DATA: {} {}".format(user_input.get(CONF_EMAIL), user_input.get(CONF_PASSWORD)))
+
+        return await self._attempt_connection(
+            user_input.get(CONF_EMAIL),
+            user_input.get(CONF_PASSWORD),
+        )

--- a/custom_components/daikin_residential/config_flow.py
+++ b/custom_components/daikin_residential/config_flow.py
@@ -49,15 +49,18 @@ class FlowHandler(config_entries.ConfigFlow):
         """Create device."""
         try:
             daikin_api = DaikinApi(self.hass, None)
-        except Exception:
-            return self.async_abort(reason="missing_config")
+        except Exception as e:
+            _LOGGER.error("Failed to initialize DaikinApi: %s", e)
+            return self.async_abort(reason="init_failed")
         try:
             await daikin_api.retrieveAccessToken(email, password)
-        except Exception:
+        except Exception as e:
+            _LOGGER.error("Failed to retrieve Access Token: %s", e)
             return self.async_abort(reason="token_retrieval_failed")
         try:
             await daikin_api.getApiInfo()
-        except Exception:
+        except Exception as e:
+            _LOGGER.error("Failed to connect to DaikinApi: %s", e)
             return self.async_abort(reason="cannot_connect")
 
         return await self._create_entry(email, password, daikin_api.tokenSet)

--- a/custom_components/daikin_residential/config_flow.py
+++ b/custom_components/daikin_residential/config_flow.py
@@ -11,6 +11,7 @@ from .const import DOMAIN, CONF_TOKENSET
 
 _LOGGER = logging.getLogger(__name__)
 
+
 @config_entries.HANDLERS.register(DOMAIN)
 class FlowHandler(config_entries.ConfigFlow):
     """Handle a config flow."""
@@ -26,10 +27,7 @@ class FlowHandler(config_entries.ConfigFlow):
     def schema(self):
         """Return current schema."""
         return vol.Schema(
-            {
-                vol.Required(CONF_EMAIL): str,
-                vol.Required(CONF_PASSWORD): str,
-            }
+            {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
         )
 
     async def _create_entry(self, email, password, tokenSet):
@@ -43,12 +41,8 @@ class FlowHandler(config_entries.ConfigFlow):
         await self.async_set_unique_id("DaikinResidentialController")
 
         return self.async_create_entry(
-            title='Daikin',
-            data={
-                CONF_EMAIL: email,
-                CONF_PASSWORD: password,
-                CONF_TOKENSET: tokenSet
-            },
+            title="Daikin",
+            data={CONF_EMAIL: email, CONF_PASSWORD: password, CONF_TOKENSET: tokenSet},
         )
 
     async def _attempt_connection(self, email, password):
@@ -56,17 +50,14 @@ class FlowHandler(config_entries.ConfigFlow):
         try:
             daikin_api = DaikinApi(self.hass, None)
         except Exception:
-            print("CAZZO1")
             return self.async_abort(reason="missing_config")
         try:
             await daikin_api.retrieveAccessToken(email, password)
         except Exception:
-            print("CAZZO2")
             return self.async_abort(reason="token_retrieval_failed")
         try:
             await daikin_api.getApiInfo()
         except Exception:
-            print("CAZZO3")
             return self.async_abort(reason="cannot_connect")
 
         return await self._create_entry(email, password, daikin_api.tokenSet)
@@ -76,15 +67,11 @@ class FlowHandler(config_entries.ConfigFlow):
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=self.schema)
         return await self._attempt_connection(
-            user_input.get(CONF_EMAIL),
-            user_input.get(CONF_PASSWORD),
+            user_input.get(CONF_EMAIL), user_input.get(CONF_PASSWORD)
         )
 
     async def async_step_import(self, user_input):
         """Import a config entry from YAML."""
-        print("YAML DATA: {} {}".format(user_input.get(CONF_EMAIL), user_input.get(CONF_PASSWORD)))
-
         return await self._attempt_connection(
-            user_input.get(CONF_EMAIL),
-            user_input.get(CONF_PASSWORD),
+            user_input.get(CONF_EMAIL), user_input.get(CONF_PASSWORD)
         )

--- a/custom_components/daikin_residential/const.py
+++ b/custom_components/daikin_residential/const.py
@@ -2,6 +2,7 @@
 
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
+    CONF_TOKEN,
     CONF_ICON,
     CONF_NAME,
     CONF_TYPE,
@@ -12,6 +13,8 @@ from homeassistant.const import (
 )
 
 DOMAIN = "daikin_residential"
+
+CONF_TOKENSET = CONF_TOKEN + "set"
 
 DAIKIN_DATA = "daikin_data"
 DAIKIN_API = "daikin_api"

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -1,13 +1,22 @@
 """Platform for the Daikin AC."""
+import base64
+import copy
 import datetime
 import functools
 import json
 import logging
+import os
+import re
 import requests
+import time
+from oic.oic import Client
+from urllib import parse
 
+import homeassistant.config_entries
 from homeassistant.util import Throttle
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
-from .const import DOMAIN, DAIKIN_DEVICES
+from .const import DOMAIN, DAIKIN_DEVICES, CONF_TOKENSET
 
 from .daikin_base import Appliance
 
@@ -15,37 +24,61 @@ _LOGGER = logging.getLogger(__name__)
 
 TOKENSET_FILE = "tokenset.json"
 
+OPENID_CLIENT_ID = '7rk39602f0ds8lk0h076vvijnb'
+
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=15)
 
 
 class DaikinApi:
     """Daikin Residential API."""
 
-    def __init__(self, hass):
+    def __init__(self, hass, entry):
         """Initialize a new Daikin Residential API."""
         #        super()
+        print("CAZZO1A")
         self.hass = hass
+        self._config_entry = entry    
         self.tokenSet = None
-        tokenFile = self.hass.config.path(TOKENSET_FILE)
-        _LOGGER.info("Initialing Daikin Residential API (%s)...", tokenFile)
-        try:
-            with open(tokenFile) as jsonFile:
-                jsonObject = json.load(jsonFile)
-                self.tokenSet = jsonObject
-                jsonFile.close()
-        except IOError:
-            _LOGGER.error("tokenset.json file not found in config folder.")
-            raise Exception("tokenset.json file not found in config folder.")
+
+        if entry is not None:
+            self.tokenSet = entry.data[CONF_TOKENSET].copy()
+        # print("CONFIG_ENTRY: {}".format(hass.config_entries['_entries']))
+        # print("CONFIG_ENTRY: {}".format(entry.data))
+        _LOGGER.info("Initialing Daikin Residential API...")
+        # tokenFile = self.hass.config.path(TOKENSET_FILE)
+        # try:
+        #     with open(tokenFile) as jsonFile:
+        #         jsonObject = json.load(jsonFile)
+        #         self.tokenSet = jsonObject
+        #         jsonFile.close()
+        # except IOError:
+        #     _LOGGER.error("tokenset.json file not found in config folder.")
+        #     raise Exception("tokenset.json file not found in config folder.")
+        print("CAZZO1B")
+
+        configuration = {
+            'issuer': 'https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_SLI9qJpc7',
+            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
+            'userinfo_endpoint': 'userinfo_endpoint',
+            'token_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/token',
+            'token_endpoint_auth_methods_supported': ['none']
+        }
+
+        self.openIdClientId = OPENID_CLIENT_ID
+        self.openIdClient = Client(client_id = self.openIdClientId, config=configuration)
+        self.openIdClient.provider_config(configuration['issuer'])
+        self.openIdStore = {}
+        print("CAZZO1C")
 
         _LOGGER.info("Initialized Daikin Residential API")
-        _LOGGER.debug(
-            "Daikin Residential API token is [%s]", self.tokenSet["access_token"]
-        )
+        # _LOGGER.debug(
+        #     "Daikin Residential API token is [%s]", self.tokenSet["access_token"]
+        # )
 
     async def doBearerRequest(self, resourceUrl, options=None, refreshed=False):
         if self.tokenSet is None:
             raise Exception(
-                "Please provide a TokenSet or use the Proxy server to Authenticate once"
+                "Missing TokenSet. Please repeat Authentication process."
             )
 
         if not resourceUrl.startswith("http"):
@@ -101,7 +134,7 @@ class DaikinApi:
             "User-Agent": "Daikin/1.6.1.4681 CFNetwork/1220.1 Darwin/20.3.0",
         }
         ref_json = {
-            "ClientId": "7rk39602f0ds8lk0h076vvijnb",
+            "ClientId": OPENID_CLIENT_ID,
             "AuthFlow": "REFRESH_TOKEN_AUTH",
             "AuthParameters": {"REFRESH_TOKEN": self.tokenSet["refresh_token"]},
         }
@@ -114,12 +147,14 @@ class DaikinApi:
         _LOGGER.info("REFRESHACCESSTOKEN RESPONSE CODE: %s", res.status_code)
         _LOGGER.debug("REFRESHACCESSTOKEN RESPONSE: %s", res.json())
         res_json = res.json()
+        data = self._config_entry.data.copy()
 
         if (
-            res_json["AuthenticationResult"] is not None
+            "AuthenticationResult" in res_json
             and res_json["AuthenticationResult"]["AccessToken"] is not None
             and res_json["AuthenticationResult"]["TokenType"] == "Bearer"
         ):
+            print("3A")
             self.tokenSet["access_token"] = res_json["AuthenticationResult"][
                 "AccessToken"
             ]
@@ -127,16 +162,266 @@ class DaikinApi:
             self.tokenSet["expires_at"] = int(
                 datetime.datetime.now().timestamp()
             ) + int(res_json["AuthenticationResult"]["ExpiresIn"])
-            _LOGGER.debug("NEW TOKENSET: %s", self.tokenSet)
-            tokenFile = self.hass.config.path(TOKENSET_FILE)
-            with open(tokenFile, "w") as outfile:
-                json.dump(self.tokenSet, outfile)
+            data[CONF_TOKENSET] = self.tokenSet
+            self.hass.config_entries.async_update_entry(entry=self._config_entry, data=data)
+            _LOGGER.info("TOKENSET REFRESHED.")
+            _LOGGER.debug("TOKENSET REFRESHED: %s", self._config_entry.data)
+
+            # tokenFile = self.hass.config.path(TOKENSET_FILE)
+            # with open(tokenFile, "w") as outfile:
+            #     json.dump(self.tokenSet, outfile)
 
             #            self.emit('token_update', self.tokenSet);
             return self.tokenSet
-        raise Exception(
-            "Token refresh was not successful! Status: " + str(res.status_code)
+
+        print("3")
+        _LOGGER.info("CANNOT REFRESH TOKENSET (%s): will login again and retrieve a new tokenSet.", res.status_code)
+        try:
+            print("4 {} {}".format(data[CONF_EMAIL], data[CONF_PASSWORD]) )
+            await self.retrieveAccessToken(data[CONF_EMAIL], data[CONF_PASSWORD])
+            data[CONF_TOKENSET] = self.tokenSet
+            self.hass.config_entries.async_update_entry(entry=self._config_entry, data=data)
+        except Exception:
+            raise Exception(
+                "Token refresh was not successful! Status: " + str(res.status_code)
+            )
+
+    async def _doAuthorizationRequest(self):
+        args = {"response_type": ["code"], "scope": "openid"}
+        state = base64.urlsafe_b64encode(os.urandom(32)).decode('utf-8').replace('=','')
+        _LOGGER.debug("STATE: %s", state)
+        args = {
+            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
+            'userinfo_endpoint': 'userinfo_endpoint',
+            'response_type': ['code'],
+            'scopes': 'email,openid,profile',
+        }
+
+        self.openIdClient.redirect_uris = ['daikinunified://login']
+        _args, code_verifier = self.openIdClient.add_code_challenge()
+        args.update(_args)
+        self.openIdStore[state] = { 'code_verifier': code_verifier }
+
+        auth_resp = self.openIdClient.do_authorization_request(request_args=args, state=state)
+        self.state = state
+        return auth_resp
+
+    async def _doAccessTokenRequest(self, callbackUrl):
+        # _LOGGER.debug('_doAccessTokenRequest: %s', callbackUrl)
+        params = dict(parse.parse_qsl(parse.urlsplit(callbackUrl).query))
+        _LOGGER.debug('VERIFIER: %s', self.openIdStore[params['state']]['code_verifier'])
+        state = self.state
+
+        args = {
+            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
+            'token_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/token',
+            'token_endpoint_auth_methods_supported': ['none'],    
+            # 'userinfo_endpoint': 'userinfo_endpoint',
+            'response_type': ['code'],
+            'scopes': 'email,openid,profile',
+            'state': state,
+            'token_endpoint_auth_method': 'none' # (default 'client_secret_basic')
+        }
+
+        if self.openIdStore[state] is None:
+             raise Exception('Cannot decode response for State ' + state + '. Please reload start page and try again!')
+
+        if params['code'] is not None:
+            callbackParams = {
+                'code_verifier': self.openIdStore[state]['code_verifier'],
+                'state': state
+            }
+            # _LOGGER.debug('CB PARAMS: %s', callbackParams)
+            # _LOGGER.debug('PROVIDER_INFO: %s', self.openIdClient.provider_info)
+            rtk_resp = self.openIdClient.do_access_token_request(request_args=args, extra_args=callbackParams, state=state, authn_method=None)
+            # _LOGGER.debug('_RETRIEVETOKENS RESP: %s', rtk_resp)
+            new_tokenset = {
+                "access_token": rtk_resp["access_token"],
+                "refresh_token": rtk_resp["refresh_token"],
+                "expires_in": rtk_resp["expires_in"],
+                "token_type": rtk_resp["token_type"]
+            }
+            _LOGGER.debug('TOKENSET RETRIEVED: %s', new_tokenset)
+            return new_tokenset
+        else:
+            raise Exception('Daikin-Cloud: ERROR.')
+ 
+    async def retrieveAccessToken(self, userName, password):
+        # Extract csrf state cookies
+        try:
+            response = await self._doAuthorizationRequest()
+            cookies = response.headers['set-cookie']
+            # _LOGGER.debug('COOKIES: %s', cookies)
+            csrfStateCookie = ''
+            for cookie in cookies.split(', '):
+                for field in cookie.split(';'):
+                    if 'csrf-state' in field:
+                        if csrfStateCookie != '':
+                            csrfStateCookie += "; "
+                        csrfStateCookie += field.strip()
+
+            # _LOGGER.debug('CSRFSTATECOOKIE COOKIES: %s', csrfStateCookie)
+            location = response.headers['location']
+            # _LOGGER.debug('LOCATION: %s', location)
+        except:
+            raise Exception('Error trying to reach Authorization URL')
+
+        # Extract SAML Context
+        try:
+            # response = await got(location, { followRedirect: false })
+            response = requests.get(location, allow_redirects=False)
+            location = response.headers['location']
+            # _LOGGER.debug('LOCATION2: %s', location)
+
+            regex = 'samlContext=([^&]+)'
+            ms = re.search(regex, location)
+            samlContext = ms[1]
+        except:
+            raise Exception('Error trying to follow redirect')
+
+        API_KEY = '3_xRB3jaQ62bVjqXU1omaEsPDVYC0Twi1zfq1zHPu_5HFT0zWkDvZJS97Yw1loJnTm'
+        API_KEY2 = '3_QebFXhxEWDc8JhJdBWmvUd1e0AaWJCISbqe4QIHrk_KzNVJFJ4xsJ2UZbl8OIIFY'
+
+        # Extract API version
+        try:
+            body = requests.get('https://cdns.gigya.com/js/gigya.js', {
+                'apiKey': API_KEY
+            }).text
+            # _LOGGER.debug('BODY: %s', body)
+            regex = '(\d+-\d-\d+)'
+            ms = re.search(regex, body)
+            version = ms[0]
+            _LOGGER.debug('VERSION: %s', version)
+        except:
+            raise Exception('Error trying to extract API version')
+
+        # Extract the cookies used for the Single Sign On
+        try:
+            ssoCookies = requests.get('https://cdc.daikin.eu/accounts.webSdkBootstrap', {
+                'apiKey': API_KEY,
+                'sdk': 'js_latest',
+                'format': 'json'
+            }).headers['set-cookie']
+            # _LOGGER.debug('SSOCOOKIES: %s', ssoCookies)
+        except:
+            raise Exception('Error trying to extract SSO cookies')
+
+        ssoCookies_arr = ssoCookies.split(', ')
+        cookies = ssoCookies_arr[0].split(';')[0].strip() + '; ' + ssoCookies_arr[2].split(';')[0].strip() + '; ' + ssoCookies_arr[4].split(';')[0].strip()
+        cookies += '; gig_bootstrap_' + API_KEY + '=cdc_ver4; '
+        cookies += 'gig_canary_' + API_KEY2 + '=false; '
+        cookies += 'gig_canary_ver_' + API_KEY2 + '=' + version + '; '
+        cookies += 'apiDomain_' + API_KEY2 + '=cdc.daikin.eu; ';
+        # _LOGGER.debug('COOKIES: %s', cookies)
+        _LOGGER.debug('SAMLCONTEXT: %s', samlContext)
+
+        # OK, now let's try to Login
+        login_token = ''
+        try:
+            headers = {
+                    'content-type': 'application/x-www-form-urlencoded',
+                    'cookie': cookies
+            }
+            req_json={
+                'loginID': userName,
+                'password': password,
+                'sessionExpiration':'31536000',
+                'targetEnv':'jssdk',
+                'include': 'profile,',
+                'loginMode': 'standard',
+                'riskContext': '{"b0":7527,"b2":4,"b5":1',
+                'APIKey': API_KEY,
+                'sdk': 'js_latest',
+                'authMode': 'cookie',
+                'pageURL': 'https://my.daikin.eu/content/daikinid-cdc-saml/en/login.html?samlContext=' + samlContext,
+                'sdkBuild': '12208',
+                'format': 'json'
+            }
+            http_args = {}
+            http_args['headers'] = headers
+
+            resp = requests.post('https://cdc.daikin.eu/accounts.login', headers=headers, data=req_json)
+            response = resp.json()
+            _LOGGER.debug('LOGIN REPLY: %s', response)
+
+            if response is not None and response['errorCode'] == 0 and response['sessionInfo'] is not None and 'login_token' in response['sessionInfo']:
+                login_token = response['sessionInfo']['login_token'];
+            else:
+                raise Exception('Unknown Login error: ' + response['errorDetails'] )
+        except:
+            raise Exception('Login failed')
+        
+        # _LOGGER.debug('LOGIN TOKEN: %s', login_token)
+
+        samlResponse = ''
+        relayState = ''
+        expiry = str(int(time.time()) + 3600000)
+        cookies = cookies + 'glt_' + API_KEY + '=' + login_token + '; '
+        cookies += 'gig_loginToken_' + API_KEY2 + '=' + login_token + '; '
+        cookies += 'gig_loginToken_' + API_KEY2 + '_exp=' + expiry + '; '
+        cookies += 'gig_loginToken_' + API_KEY2 + '_visited=%2C' + API_KEY + ';'
+        # _LOGGER.debug('COOKIES: %s', cookies)
+
+        try:
+            headers = {
+                    'cookie': cookies
+            }
+            req_json={
+                'samlContext': samlContext,
+                'loginToken': login_token
+            }
+            response = requests.post('https://cdc.daikin.eu/saml/v2.0/' + API_KEY + '/idp/sso/continue', headers=headers, data=req_json).text
+            # _LOGGER.debug('SAML: %s', response)
+            regex = 'name="SAMLResponse" value="([^"]+)"'
+            ms = re.search(regex, response)
+            samlResponse = ms[1]
+            regex = 'name="RelayState" value="([^"]+)"'
+            ms = re.search(regex, response)
+            relayState = ms[1]
+
+        except:
+            raise Exception('Authentication on SAML Identity Provider failed')
+        # _LOGGER.debug('SAMLRESPONSE: %s', samlResponse)
+        # _LOGGER.debug('RELAYSTATE: %s', relayState)
+
+
+        # Fetch the daikinunified URL
+        daikinunified = ''
+        try:
+            headers = {
+                'content-type': 'application/x-www-form-urlencoded',
+                'cookie': csrfStateCookie
+            }
+            req_json={
+                'SAMLResponse': samlResponse,
+                'RelayState': relayState
+            }
+            body = 'SAMLResponse=' + samlResponse + '&RelayState=' + relayState # : params.toString(),
+            response = requests.post('https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/saml2/idpresponse', headers=headers, data=req_json, allow_redirects=False)
+            daikinunified_url = response.headers['location']
+            # _LOGGER.debug('DAIKINUNIFIED1: %s',response)
+            # _LOGGER.debug('DAIKINUNIFIED2: %s',daikinunified)
+
+            if not 'daikinunified' in daikinunified_url:
+                raise Exception('Invalid final Authentication redirect. Location is ' + daikinunified_url)
+        except:
+            raise Exception('Impossible to retrieve SAML Identity Provider\'s response')
+
+        self.openIdClient.parse_response(
+            response=self.openIdClient.message_factory.get_response_type("authorization_endpoint"),
+            info=daikinunified_url,
+            sformat="urlencoded",
+            state=self.state
         )
+    
+        try:
+	        self.tokenSet = await self._doAccessTokenRequest(daikinunified_url)
+        except e:
+            raise Exception('Failed to retrieve access token: ' + e)
+        _LOGGER.info('NEW TOKENSET RETRIEVED.')
+        # tokenFile = self.hass.config.path('tokenset_new.json')
+        # with open(tokenFile, "w") as outfile:
+        #     json.dump(self.tokenSet, outfile)
 
     async def getApiInfo(self):
         """Get Daikin API Info."""

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -33,7 +33,7 @@ class DaikinApi:
 
     def __init__(self, hass, entry):
         """Initialize a new Daikin Residential API."""
-        _LOGGER.info("Initialing Daikin Residential API...")
+        _LOGGER.debug("Initialing Daikin Residential API...")
         self.hass = hass
         self._config_entry = entry
         self.tokenSet = None
@@ -95,7 +95,7 @@ class DaikinApi:
             return True
 
         if not refreshed and res.status_code == 401:
-            _LOGGER.info("TOKEN EXPIRED: will refresh it (%s)", res.status_code)
+            _LOGGER.debug("TOKEN EXPIRED: will refresh it (%s)", res.status_code)
             await self.refreshAccessToken()
             return await self.doBearerRequest(resourceUrl, options, True)
 
@@ -122,8 +122,8 @@ class DaikinApi:
             # res = requests.post(url, headers=headers, json=ref_json)
         except Exception as e:
             _LOGGER.error("REQUEST FAILED: %s", e)
-        _LOGGER.info("refreshAccessToken response code: %s", res.status_code)
-        _LOGGER.debug("REFRESHACCESSTOKEN RESPONSE: %s", res.json())
+        _LOGGER.debug("refreshAccessToken response code: %s", res.status_code)
+        _LOGGER.debug("refreshAccessToken response: %s", res.json())
         res_json = res.json()
         data = self._config_entry.data.copy()
 
@@ -143,12 +143,12 @@ class DaikinApi:
             self.hass.config_entries.async_update_entry(
                 entry=self._config_entry, data=data
             )
-            _LOGGER.info("TokenSet refreshed.")
-            _LOGGER.debug("TOKENSET REFRESHED: %s", self._config_entry.data)
+            _LOGGER.debug("TokenSet refreshed.")
+            # _LOGGER.debug("TOKENSET REFRESHED: %s", self._config_entry.data)
 
             return self.tokenSet
 
-        _LOGGER.info(
+        _LOGGER.warning(
             "CANNOT REFRESH TOKENSET (%s): will login again "
             + "and retrieve a new tokenSet.",
             res.status_code,
@@ -471,7 +471,7 @@ class DaikinApi:
             device = Appliance(dev_data, self)
             device_model = device.get_value("gateway", "modelInfo")
             if device_model is None:
-                _LOGGER.info("Device '%s' is filtered out", device_model)
+                _LOGGER.warning("Device '%s' is filtered out", device_model)
             else:
                 res[dev_data["id"]] = device
         return res

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -22,6 +22,9 @@ _LOGGER = logging.getLogger(__name__)
 OPENID_CLIENT_ID = "7rk39602f0ds8lk0h076vvijnb"
 DAIKIN_CLOUD_URL = "https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com"
 DAIKIN_ISSUER = "https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_SLI9qJpc7"
+API_KEY = "3_xRB3jaQ62bVjqXU1omaEsPDVYC0Twi1zfq1zHPu_5HFT0zWkDvZJS97Yw1loJnTm"
+API_KEY2 = "3_QebFXhxEWDc8JhJdBWmvUd1e0AaWJCISbqe4QIHrk_KzNVJFJ4xsJ2UZbl8OIIFY"
+
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=15)
 
 
@@ -279,9 +282,6 @@ class DaikinApi:
         except Exception as e:
             raise Exception("Error trying to follow redirect: %s", e)
         _LOGGER.debug("SAMLCONTEXT: %s", samlContext)
-
-        API_KEY = "3_xRB3jaQ62bVjqXU1omaEsPDVYC0Twi1zfq1zHPu_5HFT0zWkDvZJS97Yw1loJnTm"
-        API_KEY2 = "3_QebFXhxEWDc8JhJdBWmvUd1e0AaWJCISbqe4QIHrk_KzNVJFJ4xsJ2UZbl8OIIFY"
 
         # Extract API version
         try:

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -1,9 +1,7 @@
 """Platform for the Daikin AC."""
 import base64
-import copy
 import datetime
 import functools
-import json
 import logging
 import os
 import re
@@ -12,7 +10,6 @@ import time
 from oic.oic import Client
 from urllib import parse
 
-import homeassistant.config_entries
 from homeassistant.util import Throttle
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
@@ -22,10 +19,8 @@ from .daikin_base import Appliance
 
 _LOGGER = logging.getLogger(__name__)
 
-TOKENSET_FILE = "tokenset.json"
-
-OPENID_CLIENT_ID = '7rk39602f0ds8lk0h076vvijnb'
-
+OPENID_CLIENT_ID = "7rk39602f0ds8lk0h076vvijnb"
+DAIKIN_CLOUD_URL = "https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com"
 MIN_TIME_BETWEEN_UPDATES = datetime.timedelta(seconds=15)
 
 
@@ -35,9 +30,8 @@ class DaikinApi:
     def __init__(self, hass, entry):
         """Initialize a new Daikin Residential API."""
         #        super()
-        print("CAZZO1A")
         self.hass = hass
-        self._config_entry = entry    
+        self._config_entry = entry
         self.tokenSet = None
 
         if entry is not None:
@@ -45,30 +39,19 @@ class DaikinApi:
         # print("CONFIG_ENTRY: {}".format(hass.config_entries['_entries']))
         # print("CONFIG_ENTRY: {}".format(entry.data))
         _LOGGER.info("Initialing Daikin Residential API...")
-        # tokenFile = self.hass.config.path(TOKENSET_FILE)
-        # try:
-        #     with open(tokenFile) as jsonFile:
-        #         jsonObject = json.load(jsonFile)
-        #         self.tokenSet = jsonObject
-        #         jsonFile.close()
-        # except IOError:
-        #     _LOGGER.error("tokenset.json file not found in config folder.")
-        #     raise Exception("tokenset.json file not found in config folder.")
-        print("CAZZO1B")
 
         configuration = {
-            'issuer': 'https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_SLI9qJpc7',
-            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
-            'userinfo_endpoint': 'userinfo_endpoint',
-            'token_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/token',
-            'token_endpoint_auth_methods_supported': ['none']
+            "issuer": "https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_SLI9qJpc7",
+            "authorization_endpoint": DAIKIN_CLOUD_URL + "/oauth2/authorize",
+            "userinfo_endpoint": "userinfo_endpoint",
+            "token_endpoint": DAIKIN_CLOUD_URL + "/oauth2/token",
+            "token_endpoint_auth_methods_supported": ["none"],
         }
 
         self.openIdClientId = OPENID_CLIENT_ID
-        self.openIdClient = Client(client_id = self.openIdClientId, config=configuration)
-        self.openIdClient.provider_config(configuration['issuer'])
+        self.openIdClient = Client(client_id=self.openIdClientId, config=configuration)
+        self.openIdClient.provider_config(configuration["issuer"])
         self.openIdStore = {}
-        print("CAZZO1C")
 
         _LOGGER.info("Initialized Daikin Residential API")
         # _LOGGER.debug(
@@ -77,9 +60,7 @@ class DaikinApi:
 
     async def doBearerRequest(self, resourceUrl, options=None, refreshed=False):
         if self.tokenSet is None:
-            raise Exception(
-                "Missing TokenSet. Please repeat Authentication process."
-            )
+            raise Exception("Missing TokenSet. Please repeat Authentication process.")
 
         if not resourceUrl.startswith("http"):
             resourceUrl = "https://api.prod.unicloud.edc.dknadmin.be" + resourceUrl
@@ -154,7 +135,6 @@ class DaikinApi:
             and res_json["AuthenticationResult"]["AccessToken"] is not None
             and res_json["AuthenticationResult"]["TokenType"] == "Bearer"
         ):
-            print("3A")
             self.tokenSet["access_token"] = res_json["AuthenticationResult"][
                 "AccessToken"
             ]
@@ -163,24 +143,25 @@ class DaikinApi:
                 datetime.datetime.now().timestamp()
             ) + int(res_json["AuthenticationResult"]["ExpiresIn"])
             data[CONF_TOKENSET] = self.tokenSet
-            self.hass.config_entries.async_update_entry(entry=self._config_entry, data=data)
+            self.hass.config_entries.async_update_entry(
+                entry=self._config_entry, data=data
+            )
             _LOGGER.info("TOKENSET REFRESHED.")
             _LOGGER.debug("TOKENSET REFRESHED: %s", self._config_entry.data)
 
-            # tokenFile = self.hass.config.path(TOKENSET_FILE)
-            # with open(tokenFile, "w") as outfile:
-            #     json.dump(self.tokenSet, outfile)
-
-            #            self.emit('token_update', self.tokenSet);
             return self.tokenSet
 
-        print("3")
-        _LOGGER.info("CANNOT REFRESH TOKENSET (%s): will login again and retrieve a new tokenSet.", res.status_code)
+        _LOGGER.info(
+            "CANNOT REFRESH TOKENSET (%s): will login again "
+            + "and retrieve a new tokenSet.",
+            res.status_code,
+        )
         try:
-            print("4 {} {}".format(data[CONF_EMAIL], data[CONF_PASSWORD]) )
             await self.retrieveAccessToken(data[CONF_EMAIL], data[CONF_PASSWORD])
             data[CONF_TOKENSET] = self.tokenSet
-            self.hass.config_entries.async_update_entry(entry=self._config_entry, data=data)
+            self.hass.config_entries.async_update_entry(
+                entry=self._config_entry, data=data
+            )
         except Exception:
             raise Exception(
                 "Token refresh was not successful! Status: " + str(res.status_code)
@@ -188,189 +169,217 @@ class DaikinApi:
 
     async def _doAuthorizationRequest(self):
         args = {"response_type": ["code"], "scope": "openid"}
-        state = base64.urlsafe_b64encode(os.urandom(32)).decode('utf-8').replace('=','')
+        state = (
+            base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8").replace("=", "")
+        )
         _LOGGER.debug("STATE: %s", state)
         args = {
-            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
-            'userinfo_endpoint': 'userinfo_endpoint',
-            'response_type': ['code'],
-            'scopes': 'email,openid,profile',
+            "authorization_endpoint": DAIKIN_CLOUD_URL + "/oauth2/authorize",
+            "userinfo_endpoint": "userinfo_endpoint",
+            "response_type": ["code"],
+            "scopes": "email,openid,profile",
         }
 
-        self.openIdClient.redirect_uris = ['daikinunified://login']
+        self.openIdClient.redirect_uris = ["daikinunified://login"]
         _args, code_verifier = self.openIdClient.add_code_challenge()
         args.update(_args)
-        self.openIdStore[state] = { 'code_verifier': code_verifier }
+        self.openIdStore[state] = {"code_verifier": code_verifier}
 
-        auth_resp = self.openIdClient.do_authorization_request(request_args=args, state=state)
+        auth_resp = self.openIdClient.do_authorization_request(
+            request_args=args, state=state
+        )
         self.state = state
         return auth_resp
 
     async def _doAccessTokenRequest(self, callbackUrl):
         # _LOGGER.debug('_doAccessTokenRequest: %s', callbackUrl)
         params = dict(parse.parse_qsl(parse.urlsplit(callbackUrl).query))
-        _LOGGER.debug('VERIFIER: %s', self.openIdStore[params['state']]['code_verifier'])
+        _LOGGER.debug(
+            "VERIFIER: %s", self.openIdStore[params["state"]]["code_verifier"]
+        )
         state = self.state
 
         args = {
-            'authorization_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/authorize',
-            'token_endpoint': 'https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/oauth2/token',
-            'token_endpoint_auth_methods_supported': ['none'],    
+            "authorization_endpoint": DAIKIN_CLOUD_URL + "/oauth2/authorize",
+            "token_endpoint": DAIKIN_CLOUD_URL + "/oauth2/token",
+            "token_endpoint_auth_methods_supported": ["none"],
             # 'userinfo_endpoint': 'userinfo_endpoint',
-            'response_type': ['code'],
-            'scopes': 'email,openid,profile',
-            'state': state,
-            'token_endpoint_auth_method': 'none' # (default 'client_secret_basic')
+            "response_type": ["code"],
+            "scopes": "email,openid,profile",
+            "state": state,
+            "token_endpoint_auth_method": "none",  # (default 'client_secret_basic')
         }
 
         if self.openIdStore[state] is None:
-             raise Exception('Cannot decode response for State ' + state + '. Please reload start page and try again!')
+            raise Exception(
+                "Cannot decode response for State "
+                + state
+                + ". Please reload start page and try again!"
+            )
 
-        if params['code'] is not None:
+        if params["code"] is not None:
             callbackParams = {
-                'code_verifier': self.openIdStore[state]['code_verifier'],
-                'state': state
+                "code_verifier": self.openIdStore[state]["code_verifier"],
+                "state": state,
             }
             # _LOGGER.debug('CB PARAMS: %s', callbackParams)
             # _LOGGER.debug('PROVIDER_INFO: %s', self.openIdClient.provider_info)
-            rtk_resp = self.openIdClient.do_access_token_request(request_args=args, extra_args=callbackParams, state=state, authn_method=None)
+            rtk_resp = self.openIdClient.do_access_token_request(
+                request_args=args,
+                extra_args=callbackParams,
+                state=state,
+                authn_method=None,
+            )
             # _LOGGER.debug('_RETRIEVETOKENS RESP: %s', rtk_resp)
             new_tokenset = {
                 "access_token": rtk_resp["access_token"],
                 "refresh_token": rtk_resp["refresh_token"],
                 "expires_in": rtk_resp["expires_in"],
-                "token_type": rtk_resp["token_type"]
+                "token_type": rtk_resp["token_type"],
             }
-            _LOGGER.debug('TOKENSET RETRIEVED: %s', new_tokenset)
+            _LOGGER.debug("TOKENSET RETRIEVED: %s", new_tokenset)
             return new_tokenset
         else:
-            raise Exception('Daikin-Cloud: ERROR.')
- 
+            raise Exception("Daikin-Cloud: ERROR.")
+
     async def retrieveAccessToken(self, userName, password):
         # Extract csrf state cookies
         try:
             response = await self._doAuthorizationRequest()
-            cookies = response.headers['set-cookie']
+            cookies = response.headers["set-cookie"]
             # _LOGGER.debug('COOKIES: %s', cookies)
-            csrfStateCookie = ''
-            for cookie in cookies.split(', '):
-                for field in cookie.split(';'):
-                    if 'csrf-state' in field:
-                        if csrfStateCookie != '':
+            csrfStateCookie = ""
+            for cookie in cookies.split(", "):
+                for field in cookie.split(";"):
+                    if "csrf-state" in field:
+                        if csrfStateCookie != "":
                             csrfStateCookie += "; "
                         csrfStateCookie += field.strip()
 
             # _LOGGER.debug('CSRFSTATECOOKIE COOKIES: %s', csrfStateCookie)
-            location = response.headers['location']
+            location = response.headers["location"]
             # _LOGGER.debug('LOCATION: %s', location)
-        except:
-            raise Exception('Error trying to reach Authorization URL')
+        except Exception:
+            raise Exception("Error trying to reach Authorization URL")
 
         # Extract SAML Context
         try:
             # response = await got(location, { followRedirect: false })
             response = requests.get(location, allow_redirects=False)
-            location = response.headers['location']
+            location = response.headers["location"]
             # _LOGGER.debug('LOCATION2: %s', location)
 
-            regex = 'samlContext=([^&]+)'
+            regex = "samlContext=([^&]+)"
             ms = re.search(regex, location)
             samlContext = ms[1]
-        except:
-            raise Exception('Error trying to follow redirect')
+        except Exception:
+            raise Exception("Error trying to follow redirect")
 
-        API_KEY = '3_xRB3jaQ62bVjqXU1omaEsPDVYC0Twi1zfq1zHPu_5HFT0zWkDvZJS97Yw1loJnTm'
-        API_KEY2 = '3_QebFXhxEWDc8JhJdBWmvUd1e0AaWJCISbqe4QIHrk_KzNVJFJ4xsJ2UZbl8OIIFY'
+        API_KEY = "3_xRB3jaQ62bVjqXU1omaEsPDVYC0Twi1zfq1zHPu_5HFT0zWkDvZJS97Yw1loJnTm"
+        API_KEY2 = "3_QebFXhxEWDc8JhJdBWmvUd1e0AaWJCISbqe4QIHrk_KzNVJFJ4xsJ2UZbl8OIIFY"
 
         # Extract API version
         try:
-            body = requests.get('https://cdns.gigya.com/js/gigya.js', {
-                'apiKey': API_KEY
-            }).text
+            body = requests.get(
+                "https://cdns.gigya.com/js/gigya.js", {"apiKey": API_KEY}
+            ).text
             # _LOGGER.debug('BODY: %s', body)
-            regex = '(\d+-\d-\d+)'
+            regex = "(\d+-\d-\d+)"
             ms = re.search(regex, body)
             version = ms[0]
-            _LOGGER.debug('VERSION: %s', version)
-        except:
-            raise Exception('Error trying to extract API version')
+            _LOGGER.debug("VERSION: %s", version)
+        except Exception:
+            raise Exception("Error trying to extract API version")
 
         # Extract the cookies used for the Single Sign On
         try:
-            ssoCookies = requests.get('https://cdc.daikin.eu/accounts.webSdkBootstrap', {
-                'apiKey': API_KEY,
-                'sdk': 'js_latest',
-                'format': 'json'
-            }).headers['set-cookie']
+            ssoCookies = requests.get(
+                "https://cdc.daikin.eu/accounts.webSdkBootstrap",
+                {"apiKey": API_KEY, "sdk": "js_latest", "format": "json"},
+            ).headers["set-cookie"]
             # _LOGGER.debug('SSOCOOKIES: %s', ssoCookies)
-        except:
-            raise Exception('Error trying to extract SSO cookies')
+        except Exception:
+            raise Exception("Error trying to extract SSO cookies")
 
-        ssoCookies_arr = ssoCookies.split(', ')
-        cookies = ssoCookies_arr[0].split(';')[0].strip() + '; ' + ssoCookies_arr[2].split(';')[0].strip() + '; ' + ssoCookies_arr[4].split(';')[0].strip()
-        cookies += '; gig_bootstrap_' + API_KEY + '=cdc_ver4; '
-        cookies += 'gig_canary_' + API_KEY2 + '=false; '
-        cookies += 'gig_canary_ver_' + API_KEY2 + '=' + version + '; '
-        cookies += 'apiDomain_' + API_KEY2 + '=cdc.daikin.eu; ';
+        ssoCookies_arr = ssoCookies.split(", ")
+        cookies = (
+            ssoCookies_arr[0].split(";")[0].strip()
+            + "; "
+            + ssoCookies_arr[2].split(";")[0].strip()
+            + "; "
+            + ssoCookies_arr[4].split(";")[0].strip()
+        )
+        cookies += "; gig_bootstrap_" + API_KEY + "=cdc_ver4; "
+        cookies += "gig_canary_" + API_KEY2 + "=false; "
+        cookies += "gig_canary_ver_" + API_KEY2 + "=" + version + "; "
+        cookies += "apiDomain_" + API_KEY2 + "=cdc.daikin.eu; "
         # _LOGGER.debug('COOKIES: %s', cookies)
-        _LOGGER.debug('SAMLCONTEXT: %s', samlContext)
+        _LOGGER.debug("SAMLCONTEXT: %s", samlContext)
 
         # OK, now let's try to Login
-        login_token = ''
+        login_token = ""
         try:
             headers = {
-                    'content-type': 'application/x-www-form-urlencoded',
-                    'cookie': cookies
+                "content-type": "application/x-www-form-urlencoded",
+                "cookie": cookies,
             }
-            req_json={
-                'loginID': userName,
-                'password': password,
-                'sessionExpiration':'31536000',
-                'targetEnv':'jssdk',
-                'include': 'profile,',
-                'loginMode': 'standard',
-                'riskContext': '{"b0":7527,"b2":4,"b5":1',
-                'APIKey': API_KEY,
-                'sdk': 'js_latest',
-                'authMode': 'cookie',
-                'pageURL': 'https://my.daikin.eu/content/daikinid-cdc-saml/en/login.html?samlContext=' + samlContext,
-                'sdkBuild': '12208',
-                'format': 'json'
+            req_json = {
+                "loginID": userName,
+                "password": password,
+                "sessionExpiration": "31536000",
+                "targetEnv": "jssdk",
+                "include": "profile,",
+                "loginMode": "standard",
+                "riskContext": '{"b0":7527,"b2":4,"b5":1',
+                "APIKey": API_KEY,
+                "sdk": "js_latest",
+                "authMode": "cookie",
+                "pageURL": "https://my.daikin.eu/content/daikinid-cdc-saml/en/"
+                + "login.html?samlContext="
+                + samlContext,
+                "sdkBuild": "12208",
+                "format": "json",
             }
             http_args = {}
-            http_args['headers'] = headers
+            http_args["headers"] = headers
 
-            resp = requests.post('https://cdc.daikin.eu/accounts.login', headers=headers, data=req_json)
+            resp = requests.post(
+                "https://cdc.daikin.eu/accounts.login", headers=headers, data=req_json
+            )
             response = resp.json()
-            _LOGGER.debug('LOGIN REPLY: %s', response)
+            _LOGGER.debug("LOGIN REPLY: %s", response)
 
-            if response is not None and response['errorCode'] == 0 and response['sessionInfo'] is not None and 'login_token' in response['sessionInfo']:
-                login_token = response['sessionInfo']['login_token'];
+            if (
+                response is not None
+                and response["errorCode"] == 0
+                and response["sessionInfo"] is not None
+                and "login_token" in response["sessionInfo"]
+            ):
+                login_token = response["sessionInfo"]["login_token"]
             else:
-                raise Exception('Unknown Login error: ' + response['errorDetails'] )
-        except:
-            raise Exception('Login failed')
-        
+                raise Exception("Unknown Login error: " + response["errorDetails"])
+        except Exception:
+            raise Exception("Login failed")
+
         # _LOGGER.debug('LOGIN TOKEN: %s', login_token)
 
-        samlResponse = ''
-        relayState = ''
+        samlResponse = ""
+        relayState = ""
         expiry = str(int(time.time()) + 3600000)
-        cookies = cookies + 'glt_' + API_KEY + '=' + login_token + '; '
-        cookies += 'gig_loginToken_' + API_KEY2 + '=' + login_token + '; '
-        cookies += 'gig_loginToken_' + API_KEY2 + '_exp=' + expiry + '; '
-        cookies += 'gig_loginToken_' + API_KEY2 + '_visited=%2C' + API_KEY + ';'
+        cookies = cookies + "glt_" + API_KEY + "=" + login_token + "; "
+        cookies += "gig_loginToken_" + API_KEY2 + "=" + login_token + "; "
+        cookies += "gig_loginToken_" + API_KEY2 + "_exp=" + expiry + "; "
+        cookies += "gig_loginToken_" + API_KEY2 + "_visited=%2C" + API_KEY + ";"
         # _LOGGER.debug('COOKIES: %s', cookies)
 
         try:
-            headers = {
-                    'cookie': cookies
-            }
-            req_json={
-                'samlContext': samlContext,
-                'loginToken': login_token
-            }
-            response = requests.post('https://cdc.daikin.eu/saml/v2.0/' + API_KEY + '/idp/sso/continue', headers=headers, data=req_json).text
+            headers = {"cookie": cookies}
+            req_json = {"samlContext": samlContext, "loginToken": login_token}
+            response = requests.post(
+                "https://cdc.daikin.eu/saml/v2.0/" + API_KEY + "/idp/sso/continue",
+                headers=headers,
+                data=req_json,
+            ).text
             # _LOGGER.debug('SAML: %s', response)
             regex = 'name="SAMLResponse" value="([^"]+)"'
             ms = re.search(regex, response)
@@ -379,49 +388,52 @@ class DaikinApi:
             ms = re.search(regex, response)
             relayState = ms[1]
 
-        except:
-            raise Exception('Authentication on SAML Identity Provider failed')
+        except Exception:
+            raise Exception("Authentication on SAML Identity Provider failed")
         # _LOGGER.debug('SAMLRESPONSE: %s', samlResponse)
         # _LOGGER.debug('RELAYSTATE: %s', relayState)
 
-
         # Fetch the daikinunified URL
-        daikinunified = ''
+        daikinunified_url = ""
         try:
             headers = {
-                'content-type': 'application/x-www-form-urlencoded',
-                'cookie': csrfStateCookie
+                "content-type": "application/x-www-form-urlencoded",
+                "cookie": csrfStateCookie,
             }
-            req_json={
-                'SAMLResponse': samlResponse,
-                'RelayState': relayState
-            }
-            body = 'SAMLResponse=' + samlResponse + '&RelayState=' + relayState # : params.toString(),
-            response = requests.post('https://daikin-unicloud-prod.auth.eu-west-1.amazoncognito.com/saml2/idpresponse', headers=headers, data=req_json, allow_redirects=False)
-            daikinunified_url = response.headers['location']
+            req_json = {"SAMLResponse": samlResponse, "RelayState": relayState}
+            body = "SAMLResponse=" + samlResponse + "&RelayState=" + relayState
+            response = requests.post(
+                DAIKIN_CLOUD_URL + "/saml2/idpresponse",
+                headers=headers,
+                data=req_json,
+                allow_redirects=False,
+            )
+            daikinunified_url = response.headers["location"]
             # _LOGGER.debug('DAIKINUNIFIED1: %s',response)
             # _LOGGER.debug('DAIKINUNIFIED2: %s',daikinunified)
 
-            if not 'daikinunified' in daikinunified_url:
-                raise Exception('Invalid final Authentication redirect. Location is ' + daikinunified_url)
-        except:
-            raise Exception('Impossible to retrieve SAML Identity Provider\'s response')
+            if "daikinunified" not in daikinunified_url:
+                raise Exception(
+                    "Invalid final Authentication redirect. Location is "
+                    + daikinunified_url
+                )
+        except Exception:
+            raise Exception("Impossible to retrieve SAML Identity Provider's response")
 
         self.openIdClient.parse_response(
-            response=self.openIdClient.message_factory.get_response_type("authorization_endpoint"),
+            response=self.openIdClient.message_factory.get_response_type(
+                "authorization_endpoint"
+            ),
             info=daikinunified_url,
             sformat="urlencoded",
-            state=self.state
+            state=self.state,
         )
-    
+
         try:
-	        self.tokenSet = await self._doAccessTokenRequest(daikinunified_url)
-        except e:
-            raise Exception('Failed to retrieve access token: ' + e)
-        _LOGGER.info('NEW TOKENSET RETRIEVED.')
-        # tokenFile = self.hass.config.path('tokenset_new.json')
-        # with open(tokenFile, "w") as outfile:
-        #     json.dump(self.tokenSet, outfile)
+            self.tokenSet = await self._doAccessTokenRequest(daikinunified_url)
+        except Exception as e:
+            raise Exception("Failed to retrieve access token: " + e)
+        _LOGGER.info("NEW TOKENSET RETRIEVED.")
 
     async def getApiInfo(self):
         """Get Daikin API Info."""

--- a/custom_components/daikin_residential/manifest.json
+++ b/custom_components/daikin_residential/manifest.json
@@ -1,14 +1,16 @@
 {
   "domain": "daikin_residential",
   "name": "Daikin Residential Controller",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "documentation": "https://github.com/rospogrigio/daikin_residential/",
   "dependencies": [],
   "codeowners": [
     "@rospogrigio"
   ],
   "issue_tracker": "https://github.com/rospogrigio/daikin_residential/issues",
-  "requirements": [],
+  "requirements": [
+     "oic==1.2.1"
+  ],
   "iot_class": "cloud_polling",
   "config_flow": true
 }

--- a/custom_components/daikin_residential/strings.json
+++ b/custom_components/daikin_residential/strings.json
@@ -12,7 +12,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured]",
-      "missing_config": "[%key:common::config_flow::abort::missing_config%]",
+      "init_failed": "[%key:common::config_flow::abort::init_failed]",
       "token_retrieval_failed": "[%key:common::config_flow::abort::token_retrieval_failed]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/custom_components/daikin_residential/strings.json
+++ b/custom_components/daikin_residential/strings.json
@@ -3,14 +3,17 @@
     "step": {
       "user": {
         "title": "Configure Daikin Residential Controller AC",
-        "description": "No configuration parameters are needed in this menu.\n\nJust make sure that you have obtained your tokenset.json file using the MITM proxy procedure, and stored it in your configuration folder, then press Submit to proceed.",
+        "description": "Enter the [%key:common::config_flow::data::email] and [%key:common::config_flow::data::password%] you use to login to Daikin Cloud, then press Submit.",
         "data": {
+          "email": "[%key:common::config_flow::data::email]",
+          "password": "[%key:common::config_flow::data::password%]"
         }
       }
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured]",
       "missing_config": "[%key:common::config_flow::abort::missing_config%]",
+      "token_retrieval_failed": "[%key:common::config_flow::abort::token_retrieval_failed]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "error": {

--- a/custom_components/daikin_residential/translations/en.json
+++ b/custom_components/daikin_residential/translations/en.json
@@ -3,7 +3,8 @@
         "abort": {
             "already_configured": "The integration is already configured.",
             "cannot_connect": "Failed to connect",
-            "missing_config": "tokenset.json file not found in config folder."
+            "missing_config": "tokenset.json file not found in config folder.",
+            "token_retrieval_failed": "Failed to retrieve access token set."
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -16,8 +17,10 @@
         "step": {
             "user": {
                 "data": {
+		  "email": "Email address",
+		  "password": "Password"
                 },
-                "description": "No configuration parameters are needed in this menu.\n\nJust make sure that you have obtained your tokenset.json file using the MITM proxy procedure, and stored it in your configuration folder, then press Submit to proceed.",
+	        "description": "Enter the email address and password you use to login to Daikin Cloud, then press Submit.",
                 "title": "Configure Daikin Residential Controller AC"
             }
         }

--- a/custom_components/daikin_residential/translations/en.json
+++ b/custom_components/daikin_residential/translations/en.json
@@ -2,8 +2,8 @@
     "config": {
         "abort": {
             "already_configured": "The integration is already configured.",
-            "cannot_connect": "Failed to connect",
-            "missing_config": "tokenset.json file not found in config folder.",
+            "cannot_connect": "Failed to connect to Daikin Cloud.",
+            "init_failed": "Failed to initialize Daikin API.",
             "token_retrieval_failed": "Failed to retrieve access token set."
         },
         "error": {

--- a/info.md
+++ b/info.md
@@ -13,16 +13,19 @@ Alternatively, you can install daikin_residential through HACS by adding this re
 
 # Usage:
 
-**NOTE: You must have your Daikin Cloud token set stored as a tokenset.json file in your /config folder (the same where configuration.yaml is). For instructions on how to retrieve this file, follow the guide at https://github.com/Apollon77/daikin-controller-cloud/blob/main/PROXY.md .**
+**NOTE: since v.2.0.x, the tokenset.json file is no longer needed because the integration can connect and retrieve the tokens autonomously. When installing v.2.0.x from a previous one, the integration must be deleted and re-added.**
 
 The integration can be configured in two ways:
 
 # 1. YAML config files
 
-Just add the following line to your configuration.yaml file, and the Daikin devices connected to your cloud account will be created.
+Just add the following lines to your configuration.yaml file specifying the email and password used in the Daikin Residential App, and the Daikin devices connected to your cloud account will be created.
 
 ```
 daikin_residential:
+  email: [your_email]
+  password: [your_pwd]
+
 ```
 
 
@@ -30,7 +33,8 @@ daikin_residential:
 
 Start by going to Configuration - Integration and pressing the "+ ADD INTEGRATION" button to create a new Integration, then select Daikin Residential Controller in the drop-down menu.
 
-Follow the instruction, you have actually nothing to configure, just make sure your tokenset.json fine is in the HA config folder. After pressing the "Submit" button, the integration will be added, and the Daikin devices connected to your cloud account will be created.
+Follow the instructions, you just have to type the email and password used in the Daikin Residential App. After pressing the "Submit" button, the integration will be added, and the Daikin devices connected to your cloud account will be created.
+
 
 # To-do list:
 
@@ -39,4 +43,4 @@ Follow the instruction, you have actually nothing to configure, just make sure y
 
 # Thanks to:
 
-This code is based on @Apollon77 's great work, in finding a way to retrieve the token set, and to send the HTTP commands over the cloud. This integration would not exist without his precious job.
+This code is based on @Apollon77 's great work, in finding a way to retrieve the token set, and to send the HTTP commands over the cloud. This integration would not exist without his precious job, my job was just to find a way to port his code from nodeJS to python, and then create the integration.


### PR DESCRIPTION
Introduced TokenSet retrieval by logging in with the Daikin Cloud credentials.
A new TokenSet is automatically retrieved when expired.
Removed tokenset.json usage, now all data is stored in HA config_entries.
Introduced reload service, that allows to force the retrieval of a new TokenSet.
