### PR TITLE
Fix spurious refresh after changing the preset (close #17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyDev Eclipse projects
+.project
+.pydevproject

--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -7,6 +7,7 @@ import os
 import re
 import requests
 import time
+import asyncio
 from oic.oic import Client
 from urllib import parse
 
@@ -53,6 +54,15 @@ class DaikinApi:
         self.openIdClient = Client(client_id=self.openIdClientId, config=configuration)
         self.openIdStore = {}
 
+        # The Daikin cloud returns old settings if queried with a GET
+        # immediately after a PATCH request. Se we use this attribute
+        # to skip the first GET if a PATCH request has just been executed.
+        self._just_updated = False
+
+        # The following lock is used to serialize http requests to Daikin cloud
+        # to prevent receiving old settings while a PATCH is ongoing.
+        self._cloud_lock = asyncio.Lock()
+
         _LOGGER.info("Daikin Residential API initialized.")
 
     async def doBearerRequest(self, resourceUrl, options=None, refreshed=False):
@@ -69,22 +79,23 @@ class DaikinApi:
             "Content-Type": "application/json",
         }
 
-        _LOGGER.debug("BEARER REQUEST URL: %s", resourceUrl)
-        _LOGGER.debug("BEARER REQUEST HEADERS: %s", headers)
-        if options is not None and "method" in options and options["method"] == "PATCH":
-            _LOGGER.debug("BEARER REQUEST JSON: %s", options["json"])
-            func = functools.partial(
-                requests.patch, resourceUrl, headers=headers, data=options["json"]
-            )
-            # res = requests.patch(resourceUrl, headers=headers, data=options["json"])
-        else:
-            func = functools.partial(requests.get, resourceUrl, headers=headers)
-            # res = requests.get(resourceUrl, headers=headers)
-        try:
-            res = await self.hass.async_add_executor_job(func)
-        except Exception as e:
-            _LOGGER.error("REQUEST FAILED: %s", e)
-        _LOGGER.debug("BEARER RESPONSE CODE: %s", res.status_code)
+        async with self._cloud_lock:
+            _LOGGER.debug("BEARER REQUEST URL: %s", resourceUrl)
+            _LOGGER.debug("BEARER REQUEST HEADERS: %s", headers)
+            if options is not None and "method" in options and options["method"] == "PATCH":
+                _LOGGER.debug("BEARER REQUEST JSON: %s", options["json"])
+                func = functools.partial(
+                    requests.patch, resourceUrl, headers=headers, data=options["json"]
+                )
+                # res = requests.patch(resourceUrl, headers=headers, data=options["json"])
+            else:
+                func = functools.partial(requests.get, resourceUrl, headers=headers)
+                # res = requests.get(resourceUrl, headers=headers)
+            try:
+                res = await self.hass.async_add_executor_job(func)
+            except Exception as e:
+                _LOGGER.error("REQUEST FAILED: %s", e)
+            _LOGGER.debug("BEARER RESPONSE CODE: %s", res.status_code)
 
         if res.status_code == 200:
             try:
@@ -92,6 +103,7 @@ class DaikinApi:
             except Exception:
                 return res.text
         elif res.status_code == 204:
+            self._just_updated = True
             return True
 
         if not refreshed and res.status_code == 401:
@@ -471,7 +483,7 @@ class DaikinApi:
             device = Appliance(dev_data, self)
             device_model = device.get_value("gateway", "modelInfo")
             if device_model is None:
-                _LOGGER.warning("Device '%s' is filtered out", device_model)
+                _LOGGER.warning("Device with ID '%s' is filtered out", dev_data["id"])
             else:
                 res[dev_data["id"]] = device
         return res
@@ -479,6 +491,11 @@ class DaikinApi:
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     async def async_update(self, **kwargs):
         """Pull the latest data from Daikin."""
+        if self._just_updated:
+            self._just_updated = False
+            _LOGGER.debug("API UPDATE skipped (just updated from UI)")
+            return False
+
         _LOGGER.debug("API UPDATE")
 
         json_data = await self.getCloudDeviceDetails()
@@ -487,3 +504,19 @@ class DaikinApi:
                 self.hass.data[DOMAIN][DAIKIN_DEVICES][dev_data["id"]].setJsonData(
                     dev_data
                 )
+
+            if dev_data["managementPoints"][1]["econoMode"]["value"] == "on":
+                _mode = "eco"
+            elif dev_data["managementPoints"][1]["powerfulMode"]["value"] == "on":
+                _mode = "powerful"
+            else:
+                _mode = "none"
+
+            _LOGGER.debug("DEVICE %s: %s/%s/%s/%s",
+                dev_data["managementPoints"][1]["name"]["value"],
+                dev_data["managementPoints"][1]["onOffMode"]["value"],
+                dev_data["managementPoints"][1]["operationMode"]["value"],
+                _mode,
+                "streamer" if dev_data["managementPoints"][1]["streamerMode"]["value"] == "on" else "nostreamer")
+
+        return True


### PR DESCRIPTION
- added a private attribute to DaikinApi class to skip the first  refresh from cloud that follows a PATCH request to prevent   receiving old settings
- added a lock object to serialize http requests to cloud to prevent receiving wrong settings while a PATCH request is ongoing
- added debug log messages to track down this odd behavior