### PR TITLE
Fix UnboundLocalError in doBearerRequest()

### DIFF
--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -99,6 +99,7 @@ class DaikinApi:
                 res = await self.hass.async_add_executor_job(func)
             except Exception as e:
                 _LOGGER.error("REQUEST FAILED: %s", e)
+                raise e
             _LOGGER.debug("BEARER RESPONSE CODE: %s", res.status_code)
 
         if res.status_code == 200:


### PR DESCRIPTION
Failure to connect to the gateway leads to the following problem:

2022-01-19 11:11:54 ERROR (MainThread) [custom_components.daikin_residential.daikin_api] REQUEST FAILED: HTTPSConnectionPool(host='api.prod.unicloud.edc.dknadmin.be', port=443): Max retries exceeded with url: /v1/gateway-devices (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0xf15dd610>: Failed to establish a new connection: [Errno -3] Try again'))
2022-01-19 11:11:54 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Daikin for daikin_residential
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 313, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/config/custom_components/daikin_residential/__init__.py", line 85, in async_setup_entry
    devices = await daikin_api.getCloudDevices()
  File "/config/custom_components/daikin_residential/daikin_api.py", line 487, in getCloudDevices
    json_data = await self.getCloudDeviceDetails()
  File "/config/custom_components/daikin_residential/daikin_api.py", line 483, in getCloudDeviceDetails
    return await self.doBearerRequest("/v1/gateway-devices")
  File "/config/custom_components/daikin_residential/daikin_api.py", line 102, in doBearerRequest
    _LOGGER.debug("BEARER RESPONSE CODE: %s", res.status_code)
UnboundLocalError: local variable 'res' referenced before assignment

Raise the exception up the stack instead of dereferencing the
unassigned variable.