### PR TITLE
Filter out any Altherma model, not supported by this integration

### DIFF
--- a/custom_components/daikin_residential/daikin_api.py
+++ b/custom_components/daikin_residential/daikin_api.py
@@ -488,9 +488,12 @@ class DaikinApi:
         res = {}
         for dev_data in json_data or []:
             device = Appliance(dev_data, self)
-            device_model = device.get_value("gateway", "modelInfo")
-            if device_model is None:
+            gateway_model = device.get_value("gateway", "modelInfo")
+            device_model = device.desc["deviceModel"]
+            if gateway_model is None:
                 _LOGGER.warning("Device with ID '%s' is filtered out", dev_data["id"])
+            elif device_model == "Altherma":
+                _LOGGER.warning("Device with ID '%s' is filtered out because it is an Altherma", dev_data["id"])
             else:
                 res[dev_data["id"]] = device
         return res


### PR DESCRIPTION
Fixes #51 and implements #52. Filtering out the Altherma model had as side effect that for the regular AC units I am now able to control them through home assistant. For the alterma a different integration has to be used, see for example https://github.com/speleolontra/daikin_residential_altherma