### PR TITLE
Fan modes set as int instead of string

### DIFF
--- a/custom_components/daikin_residential/daikin_base.py
+++ b/custom_components/daikin_residential/daikin_base.py
@@ -204,7 +204,7 @@ class Appliance(DaikinResidentialDevice):  # pylint: disable=too-many-public-met
                 minVal = int(fixedModes["minValue"])
                 maxVal = int(fixedModes["maxValue"])
                 for val in range(minVal, maxVal + 1):
-                    fanModes.append(str(val))
+                    fanModes.append(val)
         return fanModes
 
     async def async_set_fan_mode(self, mode):


### PR DESCRIPTION
Hi,
i had problems with fan modes when I changed the daikin integration from the official one to this one.
Auto and silence modes were immediate and works, but for the numbers it works but it doesn't update the fan value in the lovelace card.
everything is solved by adding the fanmodes without transforming them in string