### PR TITLE
Attempt to fix missing holidayMode in BRP069B4x devices

### DIFF
--- a/custom_components/daikin_residential/daikin_base.py
+++ b/custom_components/daikin_residential/daikin_base.py
@@ -100,7 +100,8 @@ class Appliance(DaikinResidentialDevice):  # pylint: disable=too-many-public-met
             cmd_set = DAIKIN_CMD_SETS[param].copy()
         if "%operationMode%" in cmd_set[2]:
             operation_mode = self.getValue(ATTR_OPERATION_MODE)
-            cmd_set[2] = cmd_set[2].replace("%operationMode%", operation_mode)
+            if operation_mode:
+                cmd_set[2] = cmd_set[2].replace("%operationMode%", operation_mode)
         return cmd_set
 
     def getData(self, param):

--- a/custom_components/daikin_residential/daikin_base.py
+++ b/custom_components/daikin_residential/daikin_base.py
@@ -160,7 +160,8 @@ class Appliance(DaikinResidentialDevice):  # pylint: disable=too-many-public-met
     def support_preset_mode(self, mode):
         """Return True if the device supports preset mode."""
         mode = HA_PRESET_TO_DAIKIN[mode]
-        return self.getData(mode) is not None
+        mode_data = self.getData(mode)
+        return mode_data is not None and "value" in mode_data
 
     def preset_mode_status(self, mode):
         """Return the preset mode status."""


### PR DESCRIPTION
Attempt to fix #94:
looks like BRP069B4x  devices lack (or stopped supporting) holidayMode, since this snippet can be found in the json:

```
           "holidayMode": {
            "error": "INVALID_CHARACTERISTIC",
            "ref": "#holidayMode",
            "settable": true,
            "value": {
              "enabled": false,
              "startDate": "2022-03-27T22:00:00Z",
              "endDate": "2022-04-04T21:59:59Z",
              "desiredIsHolidayModeActive": null
            }

```

This PR aims to fix this issue.
