### PR TITLE
Use managementPointType as index, not embeddedId, for pure climate un…

### DIFF
--- a/custom_components/daikin_residential/device.py
+++ b/custom_components/daikin_residential/device.py
@@ -108,6 +108,7 @@ class DaikinResidentialDevice:
                 if mp[key] is None:
                     continue
                 if type(mp[key]) != dict:
+                    dataPoints[key] = mp[key]
                     continue
                 if type(mp[key]["value"]) != dict or (
                     len(mp[key]["value"]) == 1 and "enabled" in mp[key]["value"]
@@ -347,6 +348,14 @@ class DaikinResidentialDevice:
             dataPoint,
             format(dataPointDef),
         )
+
+        embeddedId = self.managementPoints[managementPoint]['embeddedId']
+        _LOGGER.debug(
+            "Management point `%s` has embeddedId '%s'",
+            managementPoint,
+            embeddedId,
+        )
+
         try:
             self._validateData(dataPoint + dataPointPath, dataPointDef, value)
         except Exception as error:
@@ -357,7 +366,7 @@ class DaikinResidentialDevice:
             "/v1/gateway-devices/"
             + self.getId()
             + "/management-points/"
-            + managementPoint
+            + embeddedId
             + "/characteristics/"
             + dataPoint
         )

--- a/custom_components/daikin_residential/device.py
+++ b/custom_components/daikin_residential/device.py
@@ -101,7 +101,7 @@ class DaikinResidentialDevice:
         dataPoints = {}
 
         for mp in self.desc["managementPoints"]:
-            #           print('AAAA: [{}] [{}]'.format(mp['embeddedId'], mp))
+            #           print('AAAA: [{}] [{}]'.format(mp['managementPointType'], mp))
             dataPoints = {}
             for key in mp.keys():
                 dataPoints[key] = {}
@@ -119,7 +119,7 @@ class DaikinResidentialDevice:
                         mp[key]["value"], {}
                     )
 
-            self.managementPoints[mp["embeddedId"]] = dataPoints
+            self.managementPoints[mp["managementPointType"]] = dataPoints
 
         # print('MPS FOUND: [{}]'.format(self.managementPoints))
         # print('MPS FOUND: [{}]'.format(self.managementPoints.keys()))


### PR DESCRIPTION
…its these have the same value, but some Altherma variants use an index (see https://github.com/BigFoot2020/daikin_residential_brp069a62/issues/13#issuecomment-1479324593), this is a step towards one Daikin Residential integration that also supports the Altherma

    * custom_components/daikin_residential/device.py: